### PR TITLE
Add new parameter: allow right aligned menu items

### DIFF
--- a/examples/st_navbar_4/streamlit_app.py
+++ b/examples/st_navbar_4/streamlit_app.py
@@ -1,0 +1,35 @@
+import streamlit as st
+from streamlit_navigation_bar import st_navbar
+
+styles = {
+    "nav": {
+        "background-color": "rgb(123, 209, 146)",
+    },
+    "div": {
+        "max-width": "32rem",
+    },
+    "span": {
+        "border-radius": "0.5rem",
+        "color": "rgb(49, 51, 63)",
+        "margin": "0 0.125rem",
+        "padding": "0.4375rem 0.625rem",
+    },
+    "active": {
+        "background-color": "rgba(255, 255, 255, 0.25)",
+    },
+    "hover": {
+        "background-color": "rgba(255, 255, 255, 0.35)",
+    },
+}
+page = st_navbar(
+    ["Home",
+     "Documentation",
+     "Examples",
+     "Community",
+     "About"],
+    styles=styles,
+)
+
+st.write(page)
+x = st.button("click me")
+st.write(x)

--- a/examples/st_navbar_5/streamlit_app.py
+++ b/examples/st_navbar_5/streamlit_app.py
@@ -1,0 +1,39 @@
+import streamlit as st
+from streamlit_navigation_bar import st_navbar
+
+styles = {
+    "nav": {
+        "background-color": "rgb(123, 209, 146)",
+        "justify-content": "space-between",
+    },
+    "div": {
+        "max-width": "32rem",
+    },
+    "span": {
+        "border-radius": "0.5rem",
+        "color": "rgb(49, 51, 63)",
+        "margin": "0 0.125rem",
+        "padding": "0.4375rem 0.625rem",
+    },
+    "active": {
+        "background-color": "rgba(255, 255, 255, 0.25)",
+    },
+    "hover": {
+        "background-color": "rgba(255, 255, 255, 0.35)",
+    },
+}
+
+right = ["Version", "User"]
+page = st_navbar(
+    ["Home",
+     "Documentation",
+     "Examples",
+     "Community",
+     "About"],
+    right=right,
+    styles=styles,
+)
+
+st.write(page)
+x = st.button("click me")
+st.write(x)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="streamlit-community-navigation-bar",
-    version="4.0.9",
+    version="4.1.0",
     description="A component that allows you to place a navigation bar in your Streamlit app.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/streamlit_navigation_bar/__init__.py
+++ b/streamlit_navigation_bar/__init__.py
@@ -249,6 +249,7 @@ sentinel = object()
 
 def st_navbar(
     pages,
+    right=None,
     selected=sentinel,
     logo_path=None,
     logo_page="Home",
@@ -271,6 +272,9 @@ def st_navbar(
     pages : list of str
         A list with the name of each page that will be displayed in the
         navigation bar.
+    right : list of str
+        A list with the name of each page that will be displayed in the
+        right part of the navigation bar.
     selected : str or None, optional
         The preselected page on first render. It can be a name from `pages`,
         the `logo_page` (when there is a logo) or ``None``. Defaults to the
@@ -365,6 +369,13 @@ def st_navbar(
        https://st-navbar-1.streamlit.app/
        height: 300px
     """
+    # Do some trickery to differentiate between
+    # the left part of the navigation menu
+    # and the right part
+    left = pages
+    right = right or []
+    pages = left + right
+
     check_pages(pages)
     check_selected(selected, logo_page, logo_path, pages)
     check_logo_path(logo_path)
@@ -390,7 +401,8 @@ def st_navbar(
     urls = _prepare_urls(urls, pages)
 
     page = _st_navbar(
-        pages=pages,
+        left=left,
+        right=right,
         default=default,
         base64_svg=base64_svg,
         logo_page=logo_page,

--- a/streamlit_navigation_bar/frontend/src/StNavbar.vue
+++ b/streamlit_navigation_bar/frontend/src/StNavbar.vue
@@ -1,6 +1,10 @@
 <template>
-  <nav :style="parseStyles(styles['nav'])">
-    <div :style="parseStyles(styles['div'])">
+  <nav 
+      class="streamlit-navbar"
+      :style="parseStyles(styles['nav'])">
+    <div 
+      class="streamlit-navbar-left"
+      :style="parseStyles(styles['div'])">
       <ul :style="parseStyles(styles['ul'])">
         <li
           v-if="args.base64_svg"
@@ -28,7 +32,34 @@
           </a>
         </li>
         <li
-          v-for="page in args.pages"
+          v-for="page in args.left"
+          :key="page"
+          :style="parseStyles(styles['li'])"
+        >
+          <a
+            :href="`${args.urls[page][0]}`"
+            :target="`${args.urls[page][1]}`"
+            :style="parseStyles(styles['a'])"
+            @click="onClicked(page)"
+          >
+            <span
+              :data-text="page"
+              :class="[{active: page === activePage}, hoverColor, hoverBgColor]"
+              :style="parseStyles(styles['span']) + parseStyles(styles['active'], page === activePage)"
+            >
+              {{ page }}
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div 
+      v-if="args.right.length"
+      class="streamlit-navbar-right"
+      :style="parseStyles(styles['div'])">
+      <ul :style="parseStyles(styles['ul'])">
+        <li
+          v-for="page in args.right"
           :key="page"
           :style="parseStyles(styles['li'])"
         >
@@ -117,6 +148,14 @@ if (!(bgColor === "")) {
 </script>
 
 <style scoped>
+@layer default {
+div.streamlit-navbar-left > ul {
+  justify-content: left;
+}
+div.streamlit-navbar-right > ul {
+  justify-content: right;
+}
+
 /* HTML tags */
 * {
   margin: 0;
@@ -183,5 +222,6 @@ span::before {
 }
 .hover-bg-color:hover {
   background-color: v-bind(bgColor) !important;
+}
 }
 </style>


### PR DESCRIPTION
This adds a new parameter `right`, which allows the same values as `pages`. It will create a rightmost section of menu items.  You may want to set `"justify-content": "space-between"` on the `nav` element.