### PR TITLE
Sidebar content background color

### DIFF
--- a/streamlit_navigation_bar/templates/base.css
+++ b/streamlit_navigation_bar/templates/base.css
@@ -143,7 +143,7 @@ section[data-testid="stSidebar"] {
 div[data-testid="stSidebarContent"] {
     /* margin-top: {{ ui.height }}; */
     top: {{ ui.height }};
-    background-color: {{ui.theme.backgroundColor}};
+    background-color: {{ui.theme.secondaryBackgroundColor}};
 }
 {% endif %}
 


### PR DESCRIPTION
Use the theme's secondary background color instead of the primary background color.